### PR TITLE
Modified to use ssh-agent instead of copying ssh keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,25 +19,13 @@ to have a working environment to connect to vCloud.
 
 ## Preparation
 
-### SSH Keys
+### SSH Agent
 
-To clone private GitHub repos, you may place your SSH key here: 
+SSH agent forwarding is enabled to allow chaining SSH connections using ssh-agent. This is useful if you want to clone a private git repository from inside the box.
 
-```
-resources/.ssh/id_rsa
-resources/.ssh/id_rsa.pub
-resources/.ssh/known_hosts
-```
+There is a good tutorial on using ssh-agent at http://mah.everybody.org/docs/ssh
 
-They will be copied into the box.
-
-On a unix host, use the following commands to fill the resources with your SSH key from the host.
-
-```bash
-mkdir resources/.ssh
-cp ~/.ssh/* resources/.ssh/
-cp ~/.vagrant.d/Vagrantfile resources/
-```
+Warning: Never connect to an untrusted host via ssh while ssh-agent is enabled.
 
 ### Create a user vagrant in your vCloud org
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,7 +14,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provision "shell", path: "scripts/install-vagrant.sh", privileged: false
   config.vm.provision "shell", path: "scripts/install-vagrant-vcloud.sh", privileged: false
   config.vm.provision "shell", path: "scripts/install-vagrantfile.sh", privileged: false
-  config.vm.provision "shell", path: "scripts/install-ssh-keys.sh", privileged: false
   config.vm.provision "shell", path: "scripts/install-node.sh", privileged: false
   config.vm.provision "shell", path: "scripts/install-xrdp.sh", privileged: false
   config.vm.provision "shell", path: "scripts/install-rdesktop.sh", privileged: false
@@ -25,6 +24,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provision :serverspec do |spec|
     spec.pattern = 'test/*_spec.rb'
   end
+
+  config.ssh.forward_agent = true
 
   config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct: true
 


### PR DESCRIPTION
I learned the syntax to use ssh-agent to forward my ssh keys to the guest OS without having to copy them. Thought you might find it useful.
